### PR TITLE
Fix global console bind

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -46,5 +46,5 @@ module.exports = function(grunt) {
     });
   });
 
-  grunt.registerTask('default', ['uglify', 'cfn-include', 'clean']);
+  grunt.registerTask('default', ['cfn-include', 'clean']);
 };

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -1,6 +1,6 @@
 module.exports = function(grunt) {
   grunt.initConfig({
-    uglify: {
+    terser: {
       dist: {
         files: [
           {
@@ -19,8 +19,8 @@ module.exports = function(grunt) {
   });
 
   //Load plugins for creating and removing minified javascript files
-  grunt.loadNpmTasks('grunt-contrib-uglify');
   grunt.loadNpmTasks('grunt-contrib-clean');
+  grunt.loadNpmTasks('grunt-terser');
 
   //Register task for compiling cfn template
   grunt.registerTask('cfn-include', 'Build cloudformation template using cfn-include', function(){
@@ -46,5 +46,5 @@ module.exports = function(grunt) {
     });
   });
 
-  grunt.registerTask('default', ['cfn-include', 'clean']);
+  grunt.registerTask('default', ['terser', 'cfn-include', 'clean']);
 };

--- a/cfn/replicator.cfn.json
+++ b/cfn/replicator.cfn.json
@@ -147,7 +147,7 @@
           "ZipFile": {
             "Fn::Include": {
               "type": "literal",
-              "location": "../lambda/replicator/index.js",
+              "location": "../lambda/replicator/index.min.js",
               "context": {
                 "replicaRegion": { "Ref": "ReplicaRegion" }
               }
@@ -210,7 +210,7 @@
           "ZipFile": {
             "Fn::Include": {
               "type": "literal",
-              "location": "../lambda/replicator/metrics.js"
+              "location": "../lambda/replicator/metrics.min.js"
             }
           }
         }
@@ -420,7 +420,7 @@
           "ZipFile": {
             "Fn::Include": {
               "type": "literal",
-              "location": "../lambda/controller/index.js",
+              "location": "../lambda/controller/index.min.js",
               "context": {
                 "replicatorFunction": { "Fn::GetAtt": [ "ReplicatorFunction", "Arn" ] },
                 "validateSourceFunction": { "Fn::GetAtt": [ "ValidateSourceFunction", "Arn" ] },
@@ -500,7 +500,7 @@
           "ZipFile": {
             "Fn::Include": {
               "type": "literal",
-              "location": "../lambda/controller/validate-source/index.js"
+              "location": "../lambda/controller/validate-source/index.min.js"
             }
           }
         }
@@ -562,7 +562,7 @@
           "ZipFile": {
             "Fn::Include": {
               "type": "literal",
-              "location": "../lambda/controller/validate-replica/index.js",
+              "location": "../lambda/controller/validate-replica/index.min.js",
               "context": {
                 "replicaRegion": { "Ref": "ReplicaRegion" }
               }
@@ -635,7 +635,7 @@
           "ZipFile": {
             "Fn::Include": {
               "type": "literal",
-              "location": "../lambda/controller/create-replica/index.js",
+              "location": "../lambda/controller/create-replica/index.min.js",
               "context": {
                 "replicaRegion": { "Ref": "ReplicaRegion" }
               }
@@ -700,7 +700,7 @@
           "ZipFile": {
             "Fn::Include": {
               "type": "literal",
-              "location": "../lambda/controller/start-replication/index.js"
+              "location": "../lambda/controller/start-replication/index.min.js"
             }
           }
         }
@@ -762,7 +762,7 @@
           "ZipFile": {
             "Fn::Include": {
               "type": "literal",
-              "location": "../lambda/controller/stop-replication/index.js"
+              "location": "../lambda/controller/stop-replication/index.min.js"
             }
           }
         }
@@ -832,7 +832,7 @@
           "ZipFile": {
             "Fn::Include": {
               "type": "literal",
-              "location": "../lambda/watcher/prefix/create.js",
+              "location": "../lambda/watcher/prefix/create.min.js",
               "context": {
                 "prefixTable": { "Ref": "PrefixTableName" },
                 "controllerTable": { "Ref": "ControllerTableName" }
@@ -935,7 +935,7 @@
           "ZipFile": {
             "Fn::Include": {
               "type": "literal",
-              "location": "../lambda/watcher/prefix/delete.js",
+              "location": "../lambda/watcher/prefix/delete.min.js",
               "context": {
                 "controllerTable": { "Ref": "ControllerTableName" }
               }
@@ -1055,7 +1055,7 @@
           "ZipFile": {
             "Fn::Include": {
               "type": "literal",
-              "location": "../lambda/watcher/prefix/init.js"
+              "location": "../lambda/watcher/prefix/init.min.js"
             }
           }
         }
@@ -1148,7 +1148,7 @@
           "ZipFile": {
             "Fn::Include": {
               "type": "literal",
-              "location": "../lambda/watcher/alarm/create.js",
+              "location": "../lambda/watcher/alarm/create.min.js",
               "context": {
                 "snsTopic": { "Ref": "WatcherAlarmTopic" },
                 "delayThreshold": { "Ref": "DelayThreshold" }
@@ -1255,7 +1255,7 @@
           "ZipFile": {
             "Fn::Include": {
               "type": "literal",
-              "location": "../lambda/watcher/alarm/delete.js"
+              "location": "../lambda/watcher/alarm/delete.min.js"
             }
           }
         }
@@ -1979,7 +1979,7 @@
           "ZipFile": {
             "Fn::Include": {
               "type": "literal",
-              "location": "../lambda/api/tables/get.js"
+              "location": "../lambda/api/tables/get.min.js"
             }
           }
         }
@@ -2075,7 +2075,7 @@
           "ZipFile": {
             "Fn::Include": {
               "type": "literal",
-              "location": "../lambda/api/tables/replications/post.js"
+              "location": "../lambda/api/tables/replications/post.min.js"
             }
           }
         }
@@ -2154,7 +2154,7 @@
           "ZipFile": {
             "Fn::Include": {
               "type": "literal",
-              "location": "../lambda/api/tables/replications/delete.js"
+              "location": "../lambda/api/tables/replications/delete.min.js"
             }
           }
         }
@@ -2233,7 +2233,7 @@
           "ZipFile": {
             "Fn::Include": {
               "type": "literal",
-              "location": "../lambda/api/tables/prefixes/post.js"
+              "location": "../lambda/api/tables/prefixes/post.min.js"
             }
           }
         }
@@ -2312,7 +2312,7 @@
           "ZipFile": {
             "Fn::Include": {
               "type": "literal",
-              "location": "../lambda/api/tables/prefixes/delete.js"
+              "location": "../lambda/api/tables/prefixes/delete.min.js"
             }
           }
         }
@@ -2391,7 +2391,7 @@
           "ZipFile": {
             "Fn::Include": {
               "type": "literal",
-              "location": "../lambda/api/tables/prefixes/post.js"
+              "location": "../lambda/api/tables/prefixes/post.min.js"
             }
           }
         }
@@ -2470,7 +2470,7 @@
           "ZipFile": {
             "Fn::Include": {
               "type": "literal",
-              "location": "../lambda/api/metrics/get.js"
+              "location": "../lambda/api/metrics/get.min.js"
             }
           }
         }

--- a/cfn/replicator.cfn.json
+++ b/cfn/replicator.cfn.json
@@ -147,7 +147,7 @@
           "ZipFile": {
             "Fn::Include": {
               "type": "literal",
-              "location": "../lambda/replicator/index.min.js",
+              "location": "../lambda/replicator/index.js",
               "context": {
                 "replicaRegion": { "Ref": "ReplicaRegion" }
               }
@@ -210,7 +210,7 @@
           "ZipFile": {
             "Fn::Include": {
               "type": "literal",
-              "location": "../lambda/replicator/metrics.min.js"
+              "location": "../lambda/replicator/metrics.js"
             }
           }
         }
@@ -420,7 +420,7 @@
           "ZipFile": {
             "Fn::Include": {
               "type": "literal",
-              "location": "../lambda/controller/index.min.js",
+              "location": "../lambda/controller/index.js",
               "context": {
                 "replicatorFunction": { "Fn::GetAtt": [ "ReplicatorFunction", "Arn" ] },
                 "validateSourceFunction": { "Fn::GetAtt": [ "ValidateSourceFunction", "Arn" ] },
@@ -500,7 +500,7 @@
           "ZipFile": {
             "Fn::Include": {
               "type": "literal",
-              "location": "../lambda/controller/validate-source/index.min.js"
+              "location": "../lambda/controller/validate-source/index.js"
             }
           }
         }
@@ -562,7 +562,7 @@
           "ZipFile": {
             "Fn::Include": {
               "type": "literal",
-              "location": "../lambda/controller/validate-replica/index.min.js",
+              "location": "../lambda/controller/validate-replica/index.js",
               "context": {
                 "replicaRegion": { "Ref": "ReplicaRegion" }
               }
@@ -635,7 +635,7 @@
           "ZipFile": {
             "Fn::Include": {
               "type": "literal",
-              "location": "../lambda/controller/create-replica/index.min.js",
+              "location": "../lambda/controller/create-replica/index.js",
               "context": {
                 "replicaRegion": { "Ref": "ReplicaRegion" }
               }
@@ -700,7 +700,7 @@
           "ZipFile": {
             "Fn::Include": {
               "type": "literal",
-              "location": "../lambda/controller/start-replication/index.min.js"
+              "location": "../lambda/controller/start-replication/index.js"
             }
           }
         }
@@ -762,7 +762,7 @@
           "ZipFile": {
             "Fn::Include": {
               "type": "literal",
-              "location": "../lambda/controller/stop-replication/index.min.js"
+              "location": "../lambda/controller/stop-replication/index.js"
             }
           }
         }
@@ -832,7 +832,7 @@
           "ZipFile": {
             "Fn::Include": {
               "type": "literal",
-              "location": "../lambda/watcher/prefix/create.min.js",
+              "location": "../lambda/watcher/prefix/create.js",
               "context": {
                 "prefixTable": { "Ref": "PrefixTableName" },
                 "controllerTable": { "Ref": "ControllerTableName" }
@@ -935,7 +935,7 @@
           "ZipFile": {
             "Fn::Include": {
               "type": "literal",
-              "location": "../lambda/watcher/prefix/delete.min.js",
+              "location": "../lambda/watcher/prefix/delete.js",
               "context": {
                 "controllerTable": { "Ref": "ControllerTableName" }
               }
@@ -1055,7 +1055,7 @@
           "ZipFile": {
             "Fn::Include": {
               "type": "literal",
-              "location": "../lambda/watcher/prefix/init.min.js"
+              "location": "../lambda/watcher/prefix/init.js"
             }
           }
         }
@@ -1148,7 +1148,7 @@
           "ZipFile": {
             "Fn::Include": {
               "type": "literal",
-              "location": "../lambda/watcher/alarm/create.min.js",
+              "location": "../lambda/watcher/alarm/create.js",
               "context": {
                 "snsTopic": { "Ref": "WatcherAlarmTopic" },
                 "delayThreshold": { "Ref": "DelayThreshold" }
@@ -1255,7 +1255,7 @@
           "ZipFile": {
             "Fn::Include": {
               "type": "literal",
-              "location": "../lambda/watcher/alarm/delete.min.js"
+              "location": "../lambda/watcher/alarm/delete.js"
             }
           }
         }
@@ -1979,7 +1979,7 @@
           "ZipFile": {
             "Fn::Include": {
               "type": "literal",
-              "location": "../lambda/api/tables/get.min.js"
+              "location": "../lambda/api/tables/get.js"
             }
           }
         }
@@ -2075,7 +2075,7 @@
           "ZipFile": {
             "Fn::Include": {
               "type": "literal",
-              "location": "../lambda/api/tables/replications/post.min.js"
+              "location": "../lambda/api/tables/replications/post.js"
             }
           }
         }
@@ -2154,7 +2154,7 @@
           "ZipFile": {
             "Fn::Include": {
               "type": "literal",
-              "location": "../lambda/api/tables/replications/delete.min.js"
+              "location": "../lambda/api/tables/replications/delete.js"
             }
           }
         }
@@ -2233,7 +2233,7 @@
           "ZipFile": {
             "Fn::Include": {
               "type": "literal",
-              "location": "../lambda/api/tables/prefixes/post.min.js"
+              "location": "../lambda/api/tables/prefixes/post.js"
             }
           }
         }
@@ -2312,7 +2312,7 @@
           "ZipFile": {
             "Fn::Include": {
               "type": "literal",
-              "location": "../lambda/api/tables/prefixes/delete.min.js"
+              "location": "../lambda/api/tables/prefixes/delete.js"
             }
           }
         }
@@ -2391,7 +2391,7 @@
           "ZipFile": {
             "Fn::Include": {
               "type": "literal",
-              "location": "../lambda/api/tables/prefixes/post.min.js"
+              "location": "../lambda/api/tables/prefixes/post.js"
             }
           }
         }
@@ -2470,7 +2470,7 @@
           "ZipFile": {
             "Fn::Include": {
               "type": "literal",
-              "location": "../lambda/api/metrics/get.min.js"
+              "location": "../lambda/api/metrics/get.js"
             }
           }
         }

--- a/lambda/api/metrics/get.js
+++ b/lambda/api/metrics/get.js
@@ -2,15 +2,10 @@
 var AWS = require('aws-sdk');
 var cloudwatch = new AWS.CloudWatch({apiVersion: "2010-08-01"});
 
+const { levelLogger } = require('../../logger');
+
 // Main handler function
-
 exports.handler = function(event, context, callback) {
-
-  //Prefix log messages with log level
-  console.log = console.log.bind(null, '[LOG]');
-  console.info = console.info.bind(null, '[INFO]');
-  console.error = console.error.bind(null, '[ERROR]');
-  console.warn = console.warn.bind(null, '[WARN]');
 
   var namespace = event.namespace;
   var metric = event.metric;
@@ -47,8 +42,8 @@ exports.handler = function(event, context, callback) {
   
   cloudwatch.getMetricStatistics(params, function(err, data){
     if(err){
-      console.error("Unable to get metric statistics");
-      console.error(err.name, "-", err.message);
+      levelLogger.error("Unable to get metric statistics");
+      levelLogger.error(err.name, "-", err.message);
       callback(err);
     }else {
       callback(null, data);

--- a/lambda/api/metrics/get.js
+++ b/lambda/api/metrics/get.js
@@ -2,7 +2,12 @@
 var AWS = require('aws-sdk');
 var cloudwatch = new AWS.CloudWatch({apiVersion: "2010-08-01"});
 
-const { levelLogger } = require('../../logger');
+const levelLogger = {
+    log: (...args) => console.log( '[LOG]', ...args),
+    info: (...args) => console.log( '[INFO]', ...args),
+    warn: (...args) => console.log( '[WARN]', ...args),
+    error: (...args) => console.log( '[ERROR]', ...args),
+};
 
 // Main handler function
 exports.handler = function(event, context, callback) {

--- a/lambda/api/tables/get.js
+++ b/lambda/api/tables/get.js
@@ -1,13 +1,26 @@
 // Dependencies
 var AWS = require('aws-sdk');
 var dynamodb = new AWS.DynamoDB.DocumentClient({ apiVersion: '2012-08-10'});
-const logger = require('../../logger');
+
+const levelLogger = {
+    log: (...args) => console.log( '[LOG]', ...args),
+    info: (...args) => console.log( '[INFO]', ...args),
+    warn: (...args) => console.log( '[WARN]', ...args),
+    error: (...args) => console.log( '[ERROR]', ...args),
+}
+
+const prefixLogger = (prefix) => ({
+    log: (...args) => levelLogger.log(`[${prefix}]`, ...args),
+    info: (...args) => levelLogger.info(`[${prefix}]`, ...args),
+    warn: (...args) => levelLogger.warn(`[${prefix}]`, ...args),
+    error: (...args) => levelLogger.error(`[${prefix}]`, ...args),
+});
 
 // Main handler function
 var handler = exports.handler = function(event, context, callback){
 
   var table = event.table;
-  const tableLogger = logger.prefixLogger(table);
+  const tableLogger = prefixLogger(table);
   
   //Grab items from table
   dynamodb.scan({

--- a/lambda/api/tables/get.js
+++ b/lambda/api/tables/get.js
@@ -1,26 +1,22 @@
 // Dependencies
 var AWS = require('aws-sdk');
 var dynamodb = new AWS.DynamoDB.DocumentClient({ apiVersion: '2012-08-10'});
+const logger = require('../../logger');
 
 // Main handler function
 var handler = exports.handler = function(event, context, callback){
 
   var table = event.table;
-
-  //Prefix log messages with log level
-  console.log = console.log.bind(null, '[LOG]', '[' + table + ']');
-  console.info = console.info.bind(null, '[INFO]', '[' + table + ']');
-  console.error = console.error.bind(null, '[ERROR]', '[' + table + ']');
-  console.warn = console.warn.bind(null, '[WARN]', '[' + table + ']');
-
+  const tableLogger = logger.prefixLogger(table);
+  
   //Grab items from table
   dynamodb.scan({
     TableName: event.table,
     AttributesToGet: event.attributes
   }, function(err, data){
     if(err){
-      console.error("Error scanning table");
-      console.error(err.code, "-", err.message);
+      tableLogger.error("Error scanning table");
+      tableLogger.error(err.code, "-", err.message);
       return callback(err);
     }
     //Return items

--- a/lambda/api/tables/prefixes/delete.js
+++ b/lambda/api/tables/prefixes/delete.js
@@ -2,16 +2,15 @@
 var AWS = require('aws-sdk');
 var dynamodb = new AWS.DynamoDB({apiVersion: "2012-08-10"});
 
+const logger = require('../../../logger');
+
 // Main handler function
 exports.handler = function(event, context, callback){
 
   var prefix = event.prefix;
   var prefixTable = event.prefixTable;
-  //Prefix log messages with log level
-  console.log = console.log.bind(null, '[LOG]', '[' + prefix + ']');
-  console.info = console.info.bind(null, '[INFO]', '[' + prefix + ']');
-  console.error = console.error.bind(null, '[ERROR]', '[' + prefix + ']');
-  console.warn = console.warn.bind(null, '[WARN]', '[' + prefix + ']');
+  
+  const prefixLogger = logger.prefixLogger(prefix);
 
   // Delete prefix from table
   var params = {
@@ -23,8 +22,8 @@ exports.handler = function(event, context, callback){
 
   dynamodb.deleteItem(params, function(err, data){
     if(err){
-      console.error("Unable to delete item from prefix table");
-      console.error(err.code, "-", err.data);
+      prefixLogger.error("Unable to delete item from prefix table");
+      prefixLogger.error(err.code, "-", err.data);
     }
     return callback(err);
   });

--- a/lambda/api/tables/prefixes/delete.js
+++ b/lambda/api/tables/prefixes/delete.js
@@ -2,7 +2,19 @@
 var AWS = require('aws-sdk');
 var dynamodb = new AWS.DynamoDB({apiVersion: "2012-08-10"});
 
-const logger = require('../../../logger');
+const levelLogger = {
+    log: (...args) => console.log( '[LOG]', ...args),
+    info: (...args) => console.log( '[INFO]', ...args),
+    warn: (...args) => console.log( '[WARN]', ...args),
+    error: (...args) => console.log( '[ERROR]', ...args),
+}
+
+const prefixLogger = (prefix) => ({
+    log: (...args) => levelLogger.log(`[${prefix}]`, ...args),
+    info: (...args) => levelLogger.info(`[${prefix}]`, ...args),
+    warn: (...args) => levelLogger.warn(`[${prefix}]`, ...args),
+    error: (...args) => levelLogger.error(`[${prefix}]`, ...args),
+});
 
 // Main handler function
 exports.handler = function(event, context, callback){
@@ -10,7 +22,7 @@ exports.handler = function(event, context, callback){
   var prefix = event.prefix;
   var prefixTable = event.prefixTable;
   
-  const prefixLogger = logger.prefixLogger(prefix);
+  const prefixLogger = prefixLogger(prefix);
 
   // Delete prefix from table
   var params = {

--- a/lambda/api/tables/prefixes/post.js
+++ b/lambda/api/tables/prefixes/post.js
@@ -2,7 +2,19 @@
 var AWS = require('aws-sdk');
 var dynamodb = new AWS.DynamoDB({apiVersion: "2012-08-10"});
 
-const logger = require('../../../logger');
+const levelLogger = {
+    log: (...args) => console.log( '[LOG]', ...args),
+    info: (...args) => console.log( '[INFO]', ...args),
+    warn: (...args) => console.log( '[WARN]', ...args),
+    error: (...args) => console.log( '[ERROR]', ...args),
+}
+
+const prefixLogger = (prefix) => ({
+    log: (...args) => levelLogger.log(`[${prefix}]`, ...args),
+    info: (...args) => levelLogger.info(`[${prefix}]`, ...args),
+    warn: (...args) => levelLogger.warn(`[${prefix}]`, ...args),
+    error: (...args) => levelLogger.error(`[${prefix}]`, ...args),
+});
 
 // Main handler function
 exports.handler = function(event, context, callback){
@@ -10,7 +22,7 @@ exports.handler = function(event, context, callback){
   var prefix = event.prefix;
   var prefixTable = event.prefixTable;
 
-  const prefixLogger = logger.prefixLogger(prefix);
+  const prefixLogger = prefixLogger(prefix);
 
   //Add prefix to table, if exists
   var params = {

--- a/lambda/api/tables/prefixes/post.js
+++ b/lambda/api/tables/prefixes/post.js
@@ -2,17 +2,15 @@
 var AWS = require('aws-sdk');
 var dynamodb = new AWS.DynamoDB({apiVersion: "2012-08-10"});
 
+const logger = require('../../../logger');
+
 // Main handler function
 exports.handler = function(event, context, callback){
 
   var prefix = event.prefix;
   var prefixTable = event.prefixTable;
 
-  //Prefix log messages with log level
-  console.log = console.log.bind(null, '[LOG]', '[' + prefix + ']');
-  console.info = console.info.bind(null, '[INFO]', '[' + prefix + ']');
-  console.error = console.error.bind(null, '[ERROR]', '[' + prefix + ']');
-  console.warn = console.warn.bind(null, '[WARN]', '[' + prefix + ']');
+  const prefixLogger = logger.prefixLogger(prefix);
 
   //Add prefix to table, if exists
   var params = {
@@ -25,12 +23,12 @@ exports.handler = function(event, context, callback){
 
   dynamodb.putItem(params, function(err, data){
     if(err){
-      console.error("Unable to write prefix to table");
+      prefixLogger.error("Unable to write prefix to table");
       if(err.code == "ConditionalCheckFailedException"){
-        console.error("Prefix already exists in table");
+        prefixLogger.error("Prefix already exists in table");
         err.message = new Error("Prefix already exists in table");
       }
-      console.error(err.code, "-", err.message);
+      prefixLogger.error(err.code, "-", err.message);
     }
     return callback(err);
   });

--- a/lambda/api/tables/replications/delete.js
+++ b/lambda/api/tables/replications/delete.js
@@ -2,13 +2,25 @@
 var AWS = require("aws-sdk");
 var dynamodb = new AWS.DynamoDB({apiVersion: "2012-08-10"});
 
-const logger = require('../../../logger');
+const levelLogger = {
+    log: (...args) => console.log( '[LOG]', ...args),
+    info: (...args) => console.log( '[INFO]', ...args),
+    warn: (...args) => console.log( '[WARN]', ...args),
+    error: (...args) => console.log( '[ERROR]', ...args),
+}
+
+const prefixLogger = (prefix) => ({
+    log: (...args) => levelLogger.log(`[${prefix}]`, ...args),
+    info: (...args) => levelLogger.info(`[${prefix}]`, ...args),
+    warn: (...args) => levelLogger.warn(`[${prefix}]`, ...args),
+    error: (...args) => levelLogger.error(`[${prefix}]`, ...args),
+});
 
 // Main handler function
 exports.handler = function(event, context, callback){
 
   var table = event.table;
-  const tableLogger = logger.prefixLogger(table);
+  const tableLogger = prefixLogger(table);
 
   var params = {
     TableName: event.controller,

--- a/lambda/api/tables/replications/delete.js
+++ b/lambda/api/tables/replications/delete.js
@@ -2,16 +2,13 @@
 var AWS = require("aws-sdk");
 var dynamodb = new AWS.DynamoDB({apiVersion: "2012-08-10"});
 
+const logger = require('../../../logger');
+
 // Main handler function
 exports.handler = function(event, context, callback){
 
   var table = event.table;
-
-  //Prefix log messages with log level
-  console.log = console.log.bind(null, '[LOG]', '[' + table + ']');
-  console.info = console.info.bind(null, '[INFO]', '[' + table + ']');
-  console.error = console.error.bind(null, '[ERROR]', '[' + table + ']');
-  console.warn = console.warn.bind(null, '[WARN]', '[' + table + ']');
+  const tableLogger = logger.prefixLogger(table);
 
   var params = {
     TableName: event.controller,
@@ -33,16 +30,16 @@ exports.handler = function(event, context, callback){
   dynamodb.updateItem(params, function(err, data){
     if(err){
       if(err.code == "ConditionalCheckFailedException"){
-        console.error("Trying to delete a replication doesn't exist");
+        tableLogger.error("Trying to delete a replication doesn't exist");
         err.message = "Replication not found in controller table";
       }else{
-        console.error("Unable to update item");
+        tableLogger.error("Unable to update item");
       }
-      console.error(err.code, "-", err.message);
+      tableLogger.error(err.code, "-", err.message);
       return callback(err);
     }
 
-    console.log("Item updated succesfully");
+    tableLogger.log("Item updated succesfully");
     callback(err, data);
   });
 };

--- a/lambda/api/tables/replications/post.js
+++ b/lambda/api/tables/replications/post.js
@@ -2,18 +2,16 @@
 var AWS = require("aws-sdk");
 var dynamodb = new AWS.DynamoDB({apiVersion: "2012-08-10"});
 
+const logger = require('../../../logger');
+
 // Main handler function
 exports.handler = function(event, context, callback){
 
   var controller = event.controller;
   var table = event.table;
-
-  //Prefix log messages with log level
-  console.log = console.log.bind(null, '[LOG]', '[' + table + ']');
-  console.info = console.info.bind(null, '[INFO]', '[' + table + ']');
-  console.error = console.error.bind(null, '[ERROR]', '[' + table + ']');
-  console.warn = console.warn.bind(null, '[WARN]', '[' + table + ']');
-
+  
+  const tableLogger = logger.prefixLogger(table);
+  
   //Verify table exists in source region
   dynamodb.describeTable({ TableName: table }, function(err, data){
     if(err){
@@ -38,15 +36,15 @@ exports.handler = function(event, context, callback){
     dynamodb.putItem(params, function(err, data){
       if(err){
         if(err.code == "ConditionalCheckFailedException"){
-          console.error("Item already exists in controller table");
+          tableLogger.error("Item already exists in controller table");
           err.message = "Table " + table + " is already being replicated";
         }else{
-          console.error("Unable to write item to table");
+          tableLogger.error("Unable to write item to table");
         }
-        console.error(err.code, "-", err.message);
+        tableLogger.error(err.code, "-", err.message);
         return callback(err);
       }
-      console.log("Response :", JSON.stringify(data));
+      tableLogger.log("Response :", JSON.stringify(data));
       return callback();
     });
   });

--- a/lambda/api/tables/replications/post.js
+++ b/lambda/api/tables/replications/post.js
@@ -2,7 +2,19 @@
 var AWS = require("aws-sdk");
 var dynamodb = new AWS.DynamoDB({apiVersion: "2012-08-10"});
 
-const logger = require('../../../logger');
+const levelLogger = {
+    log: (...args) => console.log( '[LOG]', ...args),
+    info: (...args) => console.log( '[INFO]', ...args),
+    warn: (...args) => console.log( '[WARN]', ...args),
+    error: (...args) => console.log( '[ERROR]', ...args),
+}
+
+const prefixLogger = (prefix) => ({
+    log: (...args) => levelLogger.log(`[${prefix}]`, ...args),
+    info: (...args) => levelLogger.info(`[${prefix}]`, ...args),
+    warn: (...args) => levelLogger.warn(`[${prefix}]`, ...args),
+    error: (...args) => levelLogger.error(`[${prefix}]`, ...args),
+});
 
 // Main handler function
 exports.handler = function(event, context, callback){
@@ -10,7 +22,7 @@ exports.handler = function(event, context, callback){
   var controller = event.controller;
   var table = event.table;
   
-  const tableLogger = logger.prefixLogger(table);
+  const tableLogger = prefixLogger(table);
   
   //Verify table exists in source region
   dynamodb.describeTable({ TableName: table }, function(err, data){

--- a/lambda/controller/create-replica/index.js
+++ b/lambda/controller/create-replica/index.js
@@ -6,7 +6,12 @@ var AWS = require('aws-sdk');
 var sourcedb = new AWS.DynamoDB({apiVersion: '2012-08-10', region: process.env.AWS_REGION });
 var replicadb = new AWS.DynamoDB({apiVersion: '2012-08-10', region: REPLICA_REGION});
 
-const { levelLogger } = require('../../logger');
+const levelLogger = {
+    log: (...args) => console.log( '[LOG]', ...args),
+    info: (...args) => console.log( '[INFO]', ...args),
+    warn: (...args) => console.log( '[WARN]', ...args),
+    error: (...args) => console.log( '[ERROR]', ...args),
+};
 
 // Main handler function;
 exports.handler = function(event, context, callback){

--- a/lambda/controller/index.js
+++ b/lambda/controller/index.js
@@ -13,25 +13,21 @@ var AWS = require('aws-sdk');
 var lambda = new AWS.Lambda({ apiVersion: '2015-03-31' });
 var dynamodb = new AWS.DynamoDB.DocumentClient({ apiVersion: '2012-08-10' });
 
+const { levelLogger } = require('../logger');
+
 // Main handler function
 exports.handler = function(event, context, callback){
 
-  //Bind prefix to log levels
-  console.log = console.log.bind("[LOG]");
-  console.info = console.info.bind("[INFO]");
-  console.warn = console.warn.bind("[WARN]");
-  console.error = console.error.bind("[ERROR]");
-
   //Function expects batch size of 1
   if(!event.Records || !event.Records[0] || event.Records[0].eventSource != 'aws:dynamodb'){
-    console.warn("Invalid event object, no action taken");
+    levelLogger.warn("Invalid event object, no action taken");
     return callback();
   }
 
   event = event.Records[0];
 
   if(event.eventName != 'INSERT' && event.eventName != 'MODIFY'){
-    console.log('No action taken for event', event.eventName, 'on record', JSON.stringify(event));
+    levelLogger.log('No action taken for event', event.eventName, 'on record', JSON.stringify(event));
     return callback();
   }
 
@@ -47,8 +43,8 @@ exports.handler = function(event, context, callback){
     state = event.dynamodb.NewImage.state.S;
     step = event.dynamodb.NewImage.step.S;
   }catch(err){
-    console.warn("Invalid event object, failing step");
-    console.info("Thrown:", err);
+    levelLogger.warn("Invalid event object, failing step");
+    levelLogger.info("Thrown:", err);
     return callback(new Error("Internal Error - Lambda function invoked with invalid event object"));
   }
 
@@ -75,13 +71,13 @@ exports.handler = function(event, context, callback){
 
   if(state != 'PENDING') {
     //If not pending, don't take action
-    console.log('No action taken for item with state', state);
+    levelLogger.log('No action taken for item with state', state);
     return callback();
   }
 
   if(!STEP_MAP[step]) {
     //No action for current step, so it fails
-    console.warn("No action mapped to step", step);
+    levelLogger.warn("No action mapped to step", step);
     var items = {
       step: step,
       state: "FAILED",
@@ -107,7 +103,7 @@ exports.handler = function(event, context, callback){
     if(err){
       if(err.code == "ResourceNotFoundException"){
         //Step is mapped to a lambda function that doesn't exist, fail
-        console.warn("Lambda function", STEP_MAP[step], "(mapped to step " + step + ") does not exist.");
+        levelLogger.warn("Lambda function", STEP_MAP[step], "(mapped to step " + step + ") does not exist.");
         //Simulate a function error, delaying failure until response is processed
         response = {
           FunctionError: true,
@@ -115,8 +111,8 @@ exports.handler = function(event, context, callback){
         };
       }else{
         //General failure, fail this execution to try again
-        console.error("Error invoking lambda function");
-        console.error(err.code, "-", err.message);
+        levelLogger.error("Error invoking lambda function");
+        levelLogger.error(err.code, "-", err.message);
         return callback(err);
       }
     }
@@ -127,7 +123,7 @@ exports.handler = function(event, context, callback){
 
     if(response.FunctionError){
       //Function failed execution, set state to failed, report error message
-      console.error("Function error: ", JSON.stringify(data));
+      levelLogger.error("Function error: ", JSON.stringify(data));
       items.step = step;
       items.state = 'FAILED';
       items.stateMessage = data.errorMessage;
@@ -170,7 +166,7 @@ function updateController(controller, table, items, callback){
 
   dynamodb.update(params, function(err, data){
     if(err){
-      console.error("Failed to write to controller table");
+      levelLogger.error("Failed to write to controller table");
       callback(err);
     }else{
       callback();
@@ -189,7 +185,7 @@ function deleteItem(controller, table, callback){
   };
   dynamodb.delete(params, function(err, data){
     if(err)
-      console.error("Unable to delete item from table");
+      levelLogger.error("Unable to delete item from table");
     return callback(err);
   });
 }

--- a/lambda/controller/index.js
+++ b/lambda/controller/index.js
@@ -13,7 +13,12 @@ var AWS = require('aws-sdk');
 var lambda = new AWS.Lambda({ apiVersion: '2015-03-31' });
 var dynamodb = new AWS.DynamoDB.DocumentClient({ apiVersion: '2012-08-10' });
 
-const { levelLogger } = require('../logger');
+const levelLogger = {
+    log: (...args) => console.log( '[LOG]', ...args),
+    info: (...args) => console.log( '[INFO]', ...args),
+    warn: (...args) => console.log( '[WARN]', ...args),
+    error: (...args) => console.log( '[ERROR]', ...args),
+};
 
 // Main handler function
 exports.handler = function(event, context, callback){

--- a/lambda/controller/start-replication/index.js
+++ b/lambda/controller/start-replication/index.js
@@ -6,7 +6,12 @@ var BATCH_SIZE = 25;
 var AWS = require('aws-sdk');
 var lambda = new AWS.Lambda({apiVersion: '2015-03-31'});
 
-const { levelLogger } = require('../../logger');
+const levelLogger = {
+    log: (...args) => console.log( '[LOG]', ...args),
+    info: (...args) => console.log( '[INFO]', ...args),
+    warn: (...args) => console.log( '[WARN]', ...args),
+    error: (...args) => console.log( '[ERROR]', ...args),
+};
 
 // Main handler function
 exports.handler = function(event, context, callback) {

--- a/lambda/controller/start-replication/index.js
+++ b/lambda/controller/start-replication/index.js
@@ -6,18 +6,14 @@ var BATCH_SIZE = 25;
 var AWS = require('aws-sdk');
 var lambda = new AWS.Lambda({apiVersion: '2015-03-31'});
 
+const { levelLogger } = require('../../logger');
+
 // Main handler function
 exports.handler = function(event, context, callback) {
-
-  //Bind prefix to log levels
-  console.log = console.log.bind(null, '[LOG]');
-  console.info = console.info.bind(null, '[INFO]');
-  console.warn = console.warn.bind(null, '[WARN]');
-  console.error = console.error.bind(null, '[ERROR]');
-
+  
   //Verify initialStreamArn exists in event record
   if (!event.record.initialStreamArn) {
-    console.error("Error - no streamArn provided in event record");
+    levelLogger.error("Error - no streamArn provided in event record");
     return callback(new Error("Invalid Event Record - streamArn property missing from event record"));
   }
 
@@ -32,8 +28,8 @@ exports.handler = function(event, context, callback) {
   //Add event source to replicator function
   lambda.createEventSourceMapping(params, function (err, data) {
     if (err) {
-      console.error(err.code, "-", err.message);
-      console.error("Unable to create event source mapping for lambda function");
+      levelLogger.error(err.code, "-", err.message);
+      levelLogger.error("Unable to create event source mapping for lambda function");
       return callback(err);
     }
 

--- a/lambda/controller/stop-replication/index.js
+++ b/lambda/controller/stop-replication/index.js
@@ -2,7 +2,12 @@
 var AWS = require('aws-sdk');
 var lambda = new AWS.Lambda({apiVersion: '2015-03-31'});
 
-const { levelLogger } = require('../../logger');
+const levelLogger = {
+    log: (...args) => console.log( '[LOG]', ...args),
+    info: (...args) => console.log( '[INFO]', ...args),
+    warn: (...args) => console.log( '[WARN]', ...args),
+    error: (...args) => console.log( '[ERROR]', ...args),
+};
 
 // Main handler function
 exports.handler = function(event, context, callback){

--- a/lambda/controller/stop-replication/index.js
+++ b/lambda/controller/stop-replication/index.js
@@ -2,17 +2,13 @@
 var AWS = require('aws-sdk');
 var lambda = new AWS.Lambda({apiVersion: '2015-03-31'});
 
+const { levelLogger } = require('../../logger');
+
 // Main handler function
 exports.handler = function(event, context, callback){
 
-  //Bind prefix to log levels
-  console.log = console.log.bind(null, '[LOG]');
-  console.info = console.info.bind(null, '[INFO]');
-  console.warn = console.warn.bind(null, '[WARN]');
-  console.error = console.error.bind(null, '[ERROR]');
-
   if(!event.record.UUID){
-    console.warn("No UUID in event record, assuming event source was never created");
+    levelLogger.warn("No UUID in event record, assuming event source was never created");
     return callback();
   }
 
@@ -23,12 +19,12 @@ exports.handler = function(event, context, callback){
   lambda.deleteEventSourceMapping({ UUID : UUID }, function(err, data){
     if(err){
       if(err.code == "ResourceNotFoundException"){
-        console.warn("EventSourceMapping not found, no replication to stop");
-        console.warn("Marking COMPLETE");
+        levelLogger.warn("EventSourceMapping not found, no replication to stop");
+        levelLogger.warn("Marking COMPLETE");
         return callback();
       }else{
-        console.error("Failed to delete event source mapping");
-        console.error(err.code, "-", err.message);
+        levelLogger.error("Failed to delete event source mapping");
+        levelLogger.error(err.code, "-", err.message);
         return callback(err);
       }
     }

--- a/lambda/controller/validate-replica/index.js
+++ b/lambda/controller/validate-replica/index.js
@@ -5,18 +5,14 @@ var REPLICA_REGION = "{{replicaRegion}}";
 var AWS = require('aws-sdk');
 var replicadb = new AWS.DynamoDB({apiVersion: '2012-08-10', region: REPLICA_REGION});
 
+const { levelLogger } = require('../../logger');
+
 // Main handler function
 exports.handler = function(event, context, callback){
 
-  //Bind prefix to log levels
-  console.log = console.log.bind(null, '[LOG]');
-  console.info = console.info.bind(null, '[INFO]');
-  console.warn = console.warn.bind(null, '[WARN]');
-  console.error = console.error.bind(null, '[ERROR]');
-
   //Verify keySchema exists in event record
   if(!event.record.keySchema){
-    console.error("keySchema property missing from event record");
+    levelLogger.error("keySchema property missing from event record");
     return callback(new Error("Invalid Event Record - keySchema property missing from event record"));
   }
 
@@ -27,18 +23,18 @@ exports.handler = function(event, context, callback){
     if(err){
       if (err.code === 'ResourceNotFoundException') {
         //Replica Table doesnt exist, create it
-        console.log("No replica table found");
+        levelLogger.log("No replica table found");
         return callback(null, {stateMessage: "No replica table found"});
       }else{
-        console.error("Unable to describe table");
-        console.error(err.code, "-", err.message);
+        levelLogger.error("Unable to describe table");
+        levelLogger.error(err.code, "-", err.message);
         return callback(err);
       }
     }
 
     if(JSON.stringify(data.Table.KeySchema) != keySchema){
       //Source and replica key schemas do not match, fail
-      console.error("KeySchema on replica does not match that of source");
+      levelLogger.error("KeySchema on replica does not match that of source");
       return callback(new Error("Source and Replica tables must have the same KeySchema"));
     }
 

--- a/lambda/controller/validate-replica/index.js
+++ b/lambda/controller/validate-replica/index.js
@@ -5,7 +5,12 @@ var REPLICA_REGION = "{{replicaRegion}}";
 var AWS = require('aws-sdk');
 var replicadb = new AWS.DynamoDB({apiVersion: '2012-08-10', region: REPLICA_REGION});
 
-const { levelLogger } = require('../../logger');
+const levelLogger = {
+    log: (...args) => console.log( '[LOG]', ...args),
+    info: (...args) => console.log( '[INFO]', ...args),
+    warn: (...args) => console.log( '[WARN]', ...args),
+    error: (...args) => console.log( '[ERROR]', ...args),
+};
 
 // Main handler function
 exports.handler = function(event, context, callback){

--- a/lambda/controller/validate-source/index.js
+++ b/lambda/controller/validate-source/index.js
@@ -7,7 +7,12 @@ var GLOBAL_TAG_VALUE = "true";
 var AWS = require('aws-sdk');
 var sourcedb = new AWS.DynamoDB({ apiVersion: '2012-08-10', region: process.env.AWS_REGION });
 
-const { levelLogger } = require('../../logger');
+const levelLogger = {
+    log: (...args) => console.log( '[LOG]', ...args),
+    info: (...args) => console.log( '[INFO]', ...args),
+    warn: (...args) => console.log( '[WARN]', ...args),
+    error: (...args) => console.log( '[ERROR]', ...args),
+};
 
 // Main handler function
 exports.handler = function(event, context, callback){

--- a/lambda/logger.js
+++ b/lambda/logger.js
@@ -14,11 +14,6 @@ const prefixLogger = (prefix) => ({
     error: (...args) => levelLogger.error(`[${prefix}]`, ...args),
 });
 
-const logLevel = (level, args) => {
-    console.log.apply(null, ['[' + level  + ']'].concat(args));
-};
-
-
 const levelLogger = {
     log: (...args) => console.log( '[LOG]', ...args),
     info: (...args) => console.log( '[INFO]', ...args),

--- a/lambda/logger.js
+++ b/lambda/logger.js
@@ -1,0 +1,33 @@
+const logMetric = (tableName, context, args) => console.log('[METRIC]', '[' + tableName + ']', context,  ...args);
+
+const metricsLogger = (tableName) => ({
+    all: (...args) => logMetric(tableName, 'ALL', args),
+    table: (...args) => logMetric(tableName, 'TABLE', args),
+    total: (...args) => logMetric(tableName, 'TOTAL', args),
+    none: (...args) => logMetric(tableName, 'NONE', args)
+});
+
+const prefixLogger = (prefix) => ({
+    log: (...args) => levelLogger.log(`[${prefix}]`, ...args),
+    info: (...args) => levelLogger.info(`[${prefix}]`, ...args),
+    warn: (...args) => levelLogger.warn(`[${prefix}]`, ...args),
+    error: (...args) => levelLogger.error(`[${prefix}]`, ...args),
+});
+
+const logLevel = (level, args) => {
+    console.log.apply(null, ['[' + level  + ']'].concat(args));
+};
+
+
+const levelLogger = {
+    log: (...args) => console.log( '[LOG]', ...args),
+    info: (...args) => console.log( '[INFO]', ...args),
+    warn: (...args) => console.log( '[WARN]', ...args),
+    error: (...args) => console.log( '[ERROR]', ...args),
+}
+
+module.exports = {
+    metricsLogger,
+    prefixLogger,
+    levelLogger
+};

--- a/lambda/replicator/index.js
+++ b/lambda/replicator/index.js
@@ -8,7 +8,6 @@ var RETRYABLE = [ "ProvisionedThroughputExceededException", "InternalServerError
 // Dependencies
 var AWS = require('aws-sdk');
 var dynamodb = new AWS.DynamoDB({apiVersion: '2012-08-10', region: REPLICA_REGION});
-const logger = require('../logger');
 
 const levelLogger = {
     log: (...args) => console.log( '[LOG]', ...args),

--- a/lambda/replicator/index.js
+++ b/lambda/replicator/index.js
@@ -8,29 +8,19 @@ var RETRYABLE = [ "ProvisionedThroughputExceededException", "InternalServerError
 // Dependencies
 var AWS = require('aws-sdk');
 var dynamodb = new AWS.DynamoDB({apiVersion: '2012-08-10', region: REPLICA_REGION});
+const logger = require('../logger');
 
 //  Handler function
 exports.handler = function(event, context, callback){
-
   //Pull table name from event source arn
   var tableName = event.Records[0].eventSourceARN.split('/')[1];
-
- //Prefix metrics with metric level and table name
-  console.metric = {
-    all: console.log.bind(null, '[METRIC]', '[' + tableName + ']', 'ALL'),
-    table: console.log.bind(null, '[METRIC]', '[' + tableName + ']', 'TABLE'),
-    total: console.log.bind(null, '[METRIC]', '[' + tableName + ']', 'TOTAL'),
-    none: console.log.bind(null, '[METRIC]', '[' + tableName + ']', 'NONE')
-  };
-  //Prefix log messages with log level
-  console.log = console.log.bind(null, '[LOG]', '[' + tableName + ']');
-  console.info = console.info.bind(null, '[INFO]', '[' + tableName + ']');
-  console.error = console.error.bind(null, '[ERROR]', '[' + tableName + ']');
-  console.warn = console.warn.bind(null, '[WARN]', '[' + tableName + ']');
+  
+  const metricsLogger = logger.metricsLogger(tableName);
+  const tableLogger = logger.prefixLogger(tableName);
 
   //Calculate and post metric for minutes behind record (rounded)
   var latestRecordTime= event.Records[event.Records.length - 1].dynamodb.ApproximateCreationDateTime * 1000;
-  console.metric.table("MinutesBehindRecord", Math.round((Date.now() - latestRecordTime) / 60000));
+  metricsLogger.table("MinutesBehindRecord", Math.round((Date.now() - latestRecordTime) / 60000));
 
   //For each unique table item, get the latest record
   var allRecords = event.Records.reduce(function(allRecords, record) {
@@ -53,9 +43,9 @@ exports.handler = function(event, context, callback){
         requestItems.push({ DeleteRequest: { Key: record.dynamodb.Keys } });
         break;
       default:
-        console.warn("Unknown event type '" + record.eventName + "', record will not be processed");
-        console.warn("Record data :", JSON.stringify(record));
-        console.metric.total("UnknownEventTypes");
+        tableLogger.warn("Unknown event type '" + record.eventName + "', record will not be processed");
+        tableLogger.warn("Record data :", JSON.stringify(record));
+        metricsLogger.total("UnknownEventTypes");
         break;
     }
     return requestItems;
@@ -67,7 +57,7 @@ exports.handler = function(event, context, callback){
       if(err){
         if(RETRYABLE.indexOf(err.code) > -1){
           //Error is retryable, check for / set unprocessed items and warn
-          console.warn("Retryable exception encountered :", err.code);
+          tableLogger.warn("Retryable exception encountered :", err.code);
           if(data === null || typeof(data) === "undefined"){
             data = {};
           }
@@ -76,8 +66,8 @@ exports.handler = function(event, context, callback){
           }
         }else{
           //Error is not retryable, exit with error
-          console.error("Non-retryable exception encountered\n", err.code, "-", err.message);
-          console.error("Request Items:", JSON.stringify(requestItems));
+          tableLogger.error("Non-retryable exception encountered\n", err.code, "-", err.message);
+          tableLogger.error("Request Items:", JSON.stringify(requestItems));
           return callback(err);
         }
       }
@@ -89,20 +79,20 @@ exports.handler = function(event, context, callback){
 
         if(delay + TIMEOUT_PADDING_MS >= context.getRemainingTimeInMillis()){
           //Lambda function will time out before request completes, exit with error
-          console.error("Lambda function timed out after", attempt, "attempts");
-          console.error("Request Items:", JSON.stringify(data.UnprocessedItems));
+          tableLogger.error("Lambda function timed out after", attempt, "attempts");
+          tableLogger.error("Request Items:", JSON.stringify(data.UnprocessedItems));
           return callback(new Error("Lambda function timed out after", attempts, "failed attempts"));
         }
 
         //Re-execute this function with unprocessed items after a delay
-        console.log("Retrying batch write item request with unprocessed items in " + delay + " seconds");
+        tableLogger.log("Retrying batch write item request with unprocessed items in " + delay + " seconds");
         setTimeout(batchWrite, delay, data.UnprocessedItems, ++attempt);
       }else{
         //There is no unprocessed items, post metrics and exit succesfully
-        console.metric.all("RecordsProcessed", event.Records.length);
-        console.metric.none("RecordsWritten", Object.keys(allRecords).length);
+        metricsLogger.all("RecordsProcessed", event.Records.length);
+        metricsLogger.none("RecordsWritten", Object.keys(allRecords).length);
         if(attempt - 1 > 0)
-          console.metric.table("ThrottledRequests", attempt - 1);
+          metricsLogger.table("ThrottledRequests", attempt - 1);
         callback();
       }
     });

--- a/lambda/replicator/metrics.js
+++ b/lambda/replicator/metrics.js
@@ -6,7 +6,12 @@ var zlib = require('zlib');
 var AWS = require('aws-sdk');
 var cloudwatch = new AWS.CloudWatch({apiVersion: '2010-08-01'});
 
-const { levelLogger } = require('../logger');
+const levelLogger = {
+    log: (...args) => console.log( '[LOG]', ...args),
+    info: (...args) => console.log( '[INFO]', ...args),
+    warn: (...args) => console.log( '[WARN]', ...args),
+    error: (...args) => console.log( '[ERROR]', ...args),
+};
 
 // Handler function
 exports.handler = function(event, context, callback) {

--- a/lambda/replicator/metrics.js
+++ b/lambda/replicator/metrics.js
@@ -6,13 +6,15 @@ var zlib = require('zlib');
 var AWS = require('aws-sdk');
 var cloudwatch = new AWS.CloudWatch({apiVersion: '2010-08-01'});
 
+const { levelLogger } = require('../logger');
+
 // Handler function
 exports.handler = function(event, context, callback) {
   //Unzip and parse payload
   var payload = new Buffer(event.awslogs.data, 'base64');
   zlib.gunzip(payload, function (err, result) {
     if (err) {
-      console.error("Unable to unzip event");
+      levelLogger.error("Unable to unzip event");
       return callback(err);
     }
 
@@ -51,9 +53,9 @@ function processMetrics(event, callback){
     };
     cloudwatch.putMetricData(params, function (err, data) {
       if (err) {
-        console.error("Unable to write metric data to cloudwatch");
-        console.error(err.name, "-", err.message);
-        console.error("Failed metric data:", JSON.stringify(metricGroup));
+        levelLogger.error("Unable to write metric data to cloudwatch");
+        levelLogger.error(err.name, "-", err.message);
+        levelLogger.error("Failed metric data:", JSON.stringify(metricGroup));
       }
     });
   });

--- a/lambda/watcher/alarm/create.js
+++ b/lambda/watcher/alarm/create.js
@@ -8,7 +8,12 @@ var SNS_TOPIC = "{{snsTopic}}";
 var AWS = require('aws-sdk');
 var cloudwatch = new AWS.CloudWatch({apiVersion: '2010-08-01'});
 
-const { levelLogger } = require('../../logger');
+const levelLogger = {
+    log: (...args) => console.log( '[LOG]', ...args),
+    info: (...args) => console.log( '[INFO]', ...args),
+    warn: (...args) => console.log( '[WARN]', ...args),
+    error: (...args) => console.log( '[ERROR]', ...args),
+};
 
 //  Handler function
 exports.handler = function(event, context, callback){

--- a/lambda/watcher/alarm/create.js
+++ b/lambda/watcher/alarm/create.js
@@ -8,19 +8,15 @@ var SNS_TOPIC = "{{snsTopic}}";
 var AWS = require('aws-sdk');
 var cloudwatch = new AWS.CloudWatch({apiVersion: '2010-08-01'});
 
+const { levelLogger } = require('../../logger');
+
 //  Handler function
 exports.handler = function(event, context, callback){
 
-  //Bind prefix to log levels
-  console.log = console.log.bind(null, '[LOG]');
-  console.info = console.info.bind(null, '[INFO]');
-  console.warn = console.warn.bind(null, '[WARN]');
-  console.error = console.error.bind(null, '[ERROR]');
-
   // Don't act unless request was successful
   if(event.detail.errorCode){
-    console.warn("Request returned an error, event source failed to create");
-    console.warn("No action taken");
+    levelLogger.warn("Request returned an error, event source failed to create");
+    levelLogger.warn("No action taken");
     return callback();
   }
 
@@ -28,15 +24,15 @@ exports.handler = function(event, context, callback){
 
   initMetric(tableName, function(err, data){
     if(err){
-      console.error("Error initializing metric for table", tableName);
-      console.error(err.code, "-", err.message);
+      levelLogger.error("Error initializing metric for table", tableName);
+      levelLogger.error(err.code, "-", err.message);
       return callback(err);
     }
 
     createAlarm(tableName, function(err, data){
       if(err){
-        console.error("Error creating alarm for table", tableName);
-        console.error(err.code, "-", err.message);
+        levelLogger.error("Error creating alarm for table", tableName);
+        levelLogger.error(err.code, "-", err.message);
       }
 
       callback(err, data);

--- a/lambda/watcher/alarm/delete.js
+++ b/lambda/watcher/alarm/delete.js
@@ -2,7 +2,12 @@
 var AWS = require('aws-sdk');
 var cloudwatch = new AWS.CloudWatch({apiVersion: '2010-08-01'});
 
-const { levelLogger } = require('../../logger');
+const levelLogger = {
+    log: (...args) => console.log( '[LOG]', ...args),
+    info: (...args) => console.log( '[INFO]', ...args),
+    warn: (...args) => console.log( '[WARN]', ...args),
+    error: (...args) => console.log( '[ERROR]', ...args),
+};
 
 // Handler function
 exports.handler = function(event, context, callback){

--- a/lambda/watcher/alarm/delete.js
+++ b/lambda/watcher/alarm/delete.js
@@ -2,19 +2,15 @@
 var AWS = require('aws-sdk');
 var cloudwatch = new AWS.CloudWatch({apiVersion: '2010-08-01'});
 
+const { levelLogger } = require('../../logger');
+
 // Handler function
 exports.handler = function(event, context, callback){
 
-  //Bind prefix to log levels
-  console.log = console.log.bind(null, '[LOG]');
-  console.info = console.info.bind(null, '[INFO]');
-  console.warn = console.warn.bind(null, '[WARN]');
-  console.error = console.error.bind(null, '[ERROR]');
-
   // Don't act unless request was successful
   if(event.detail.errorCode){
-    console.warn("Request returned an error, event source failed to delete");
-    console.warn("No action taken");
+    levelLogger.warn("Request returned an error, event source failed to delete");
+    levelLogger.warn("No action taken");
     return callback();
   }
 
@@ -23,8 +19,8 @@ exports.handler = function(event, context, callback){
 
   cloudwatch.deleteAlarms({ AlarmNames: [ alarmName ] }, function(err, data){
     if(err){
-      console.error("Unable to delete alarm");
-      console.error(err.code, "-", err.message);
+      levelLogger.error("Unable to delete alarm");
+      levelLogger.error(err.code, "-", err.message);
     }
 
     callback(err);

--- a/lambda/watcher/prefix/create.js
+++ b/lambda/watcher/prefix/create.js
@@ -6,7 +6,12 @@ var CONTROLLER_TABLE = "{{controllerTable}}";
 var AWS = require('aws-sdk');
 var dynamodb = new AWS.DynamoDB.DocumentClient({apiVersion: '2012-08-10'});
 
-const { levelLogger } = require('../../logger');
+const levelLogger = {
+    log: (...args) => console.log( '[LOG]', ...args),
+    info: (...args) => console.log( '[INFO]', ...args),
+    warn: (...args) => console.log( '[WARN]', ...args),
+    error: (...args) => console.log( '[ERROR]', ...args),
+};
 
 // Main handler function
 exports.handler = function(event, context, callback){

--- a/lambda/watcher/prefix/delete.js
+++ b/lambda/watcher/prefix/delete.js
@@ -5,7 +5,12 @@ var CONTROLLER_TABLE = "{{controllerTable}}";
 var AWS = require('aws-sdk');
 var dynamodb = new AWS.DynamoDB({apiVersion: '2012-08-10'});
 
-const { levelLogger } = require('../../logger');
+const levelLogger = {
+    log: (...args) => console.log( '[LOG]', ...args),
+    info: (...args) => console.log( '[INFO]', ...args),
+    warn: (...args) => console.log( '[WARN]', ...args),
+    error: (...args) => console.log( '[ERROR]', ...args),
+};
 
 // Main handler function
 exports.handler = function(event, context, callback){

--- a/lambda/watcher/prefix/delete.js
+++ b/lambda/watcher/prefix/delete.js
@@ -5,18 +5,14 @@ var CONTROLLER_TABLE = "{{controllerTable}}";
 var AWS = require('aws-sdk');
 var dynamodb = new AWS.DynamoDB({apiVersion: '2012-08-10'});
 
+const { levelLogger } = require('../../logger');
+
 // Main handler function
 exports.handler = function(event, context, callback){
 
-  //Bind prefix to log levels
-  console.log = console.log.bind(null, '[LOG]');
-  console.info = console.info.bind(null, '[INFO]');
-  console.warn = console.warn.bind(null, '[WARN]');
-  console.error = console.error.bind(null, '[ERROR]');
-
   //Ensure event was successful
   if(event.detail.errorCode){
-    console.warn("Table failed to delete, no action taken");
+    levelLogger.warn("Table failed to delete, no action taken");
     return callback();
   }
 
@@ -44,16 +40,16 @@ exports.handler = function(event, context, callback){
   dynamodb.updateItem(params, function(err, data){
     if(err){
       if(err.code == "ConditionalCheckFailedException"){
-        console.log("Table", table, "not found in controller, no action taken");
+        levelLogger.log("Table", table, "not found in controller, no action taken");
         return callback();
       }else{
-        console.error("Unable to update item");
-        console.error(err.code, "-", err.message);
+        levelLogger.error("Unable to update item");
+        levelLogger.error(err.code, "-", err.message);
         return callback(err);
       }
     }
 
-    console.log("Removal of replication for table", table, "initialized");
+    levelLogger.log("Removal of replication for table", table, "initialized");
     return callback();
   });
 };

--- a/lambda/watcher/prefix/init.js
+++ b/lambda/watcher/prefix/init.js
@@ -3,7 +3,12 @@ var AWS = require('aws-sdk');
 var dynamodb = new AWS.DynamoDB({ apiVersion: '2012-08-10' });
 var cloudwatch = new AWS.CloudWatchEvents({ apiVersion: '2015-10-07' });
 
-const { levelLogger } = require('../../logger');
+const levelLogger = {
+    log: (...args) => console.log( '[LOG]', ...args),
+    info: (...args) => console.log( '[INFO]', ...args),
+    warn: (...args) => console.log( '[WARN]', ...args),
+    error: (...args) => console.log( '[ERROR]', ...args),
+};
 
 // Handler Function
 exports.handler = function(event, context, callback){

--- a/lambda/watcher/prefix/init.js
+++ b/lambda/watcher/prefix/init.js
@@ -3,18 +3,14 @@ var AWS = require('aws-sdk');
 var dynamodb = new AWS.DynamoDB({ apiVersion: '2012-08-10' });
 var cloudwatch = new AWS.CloudWatchEvents({ apiVersion: '2015-10-07' });
 
+const { levelLogger } = require('../../logger');
+
 // Handler Function
 exports.handler = function(event, context, callback){
 
-  //Prefix log messages with log level
-  console.log = console.log.bind(null, '[LOG]');
-  console.info = console.info.bind(null, '[INFO]');
-  console.error = console.error.bind(null, '[ERROR]');
-  console.warn = console.warn.bind(null, '[WARN]');
-
   //Only act on new prefixes
   if(event.Records[0].eventName !== "INSERT"){
-    console.warn("No action taken for event of type", event.Records[0].eventName);
+    levelLogger.warn("No action taken for event of type", event.Records[0].eventName);
     return callback();
   }
   //Grab Prefix from event
@@ -22,8 +18,8 @@ exports.handler = function(event, context, callback){
 
   listPrefixedTables(prefix, function(err, tables){
     if(err){
-      console.error("Unable to list tables");
-      console.error(err.code, "-", err.message);
+      levelLogger.error("Unable to list tables");
+      levelLogger.error(err.code, "-", err.message);
       return callback(err);
     }
 
@@ -44,8 +40,8 @@ function createReplications(tables, callback){
   (function putEvents(events){
     cloudwatch.putEvents({ Entries: events }, function(err, data){
       if(err){
-        console.error("Unable to post custom CloudWatch events")
-        console.error(err.code, "-", err.message);
+        levelLogger.error("Unable to post custom CloudWatch events")
+        levelLogger.error(err.code, "-", err.message);
         return callback(err);
       }
 
@@ -53,13 +49,13 @@ function createReplications(tables, callback){
       if(data.FailedEntryCount > 0){
         var failedEntries = [];
         for(var i = 0; i < data.Entries.length; i++){
-          console.warn(data.FailedEntryCount, " failed entries");
+          levelLogger.warn(data.FailedEntryCount, " failed entries");
           if(data.Entries[i].ErrorCode){
-            console.warn(data.Entries[i].ErrorCode, "-", data.Entris[i].ErrorMessage);
+            levelLogger.warn(data.Entries[i].ErrorCode, "-", data.Entris[i].ErrorMessage);
             failedEntries.push(events[i]);
           }
         }
-        console.warn("Retrying put for", data.FailedEntryCount, "entries");
+        levelLogger.warn("Retrying put for", data.FailedEntryCount, "entries");
         putEvents(failedEntries);
       }else{
         // Loop until no batches are left to be processed

--- a/package-lock.json
+++ b/package-lock.json
@@ -28,23 +28,6 @@
         "uri-js": "^4.2.2"
       }
     },
-    "align-text": {
-      "version": "0.1.4",
-      "resolved": "https://signiant.jfrog.io/signiant/api/npm/npm-virt/align-text/-/align-text-0.1.4.tgz",
-      "integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=",
-      "dev": true,
-      "requires": {
-        "kind-of": "^3.0.2",
-        "longest": "^1.0.1",
-        "repeat-string": "^1.5.2"
-      }
-    },
-    "ansi-regex": {
-      "version": "2.1.1",
-      "resolved": "https://signiant.jfrog.io/signiant/api/npm/npm-virt/ansi-regex/-/ansi-regex-2.1.1.tgz",
-      "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
-      "dev": true
-    },
     "ansi-styles": {
       "version": "1.0.0",
       "resolved": "https://signiant.jfrog.io/signiant/api/npm/npm-virt/ansi-styles/-/ansi-styles-1.0.0.tgz",
@@ -175,15 +158,6 @@
         "concat-map": "0.0.1"
       }
     },
-    "browserify-zlib": {
-      "version": "0.1.4",
-      "resolved": "https://signiant.jfrog.io/signiant/api/npm/npm-virt/browserify-zlib/-/browserify-zlib-0.1.4.tgz",
-      "integrity": "sha1-uzX4pRn2AOD6a4SFJByXnQFB+y0=",
-      "dev": true,
-      "requires": {
-        "pako": "~0.2.0"
-      }
-    },
     "buffer": {
       "version": "4.9.1",
       "resolved": "https://signiant.jfrog.io/signiant/api/npm/npm-virt/buffer/-/buffer-4.9.1.tgz",
@@ -223,16 +197,6 @@
       "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=",
       "dev": true
     },
-    "center-align": {
-      "version": "0.1.3",
-      "resolved": "https://signiant.jfrog.io/signiant/api/npm/npm-virt/center-align/-/center-align-0.1.3.tgz",
-      "integrity": "sha1-qg0yYptu6XIgBBHL1EYckHvCt60=",
-      "dev": true,
-      "requires": {
-        "align-text": "^0.1.3",
-        "lazy-cache": "^1.0.3"
-      }
-    },
     "cfn-include": {
       "version": "0.6.4",
       "resolved": "https://signiant.jfrog.io/signiant/api/npm/npm-virt/cfn-include/-/cfn-include-0.6.4.tgz",
@@ -259,17 +223,6 @@
         "ansi-styles": "~1.0.0",
         "has-color": "~0.1.0",
         "strip-ansi": "~0.1.0"
-      }
-    },
-    "cliui": {
-      "version": "2.1.0",
-      "resolved": "https://signiant.jfrog.io/signiant/api/npm/npm-virt/cliui/-/cliui-2.1.0.tgz",
-      "integrity": "sha1-S0dXYP+AJkx2LDoXGQMukcf+oNE=",
-      "dev": true,
-      "requires": {
-        "center-align": "^0.1.1",
-        "right-align": "^0.1.1",
-        "wordwrap": "0.0.2"
       }
     },
     "coffeescript": {
@@ -308,23 +261,17 @@
         "delayed-stream": "~1.0.0"
       }
     },
+    "commander": {
+      "version": "2.20.3",
+      "resolved": "https://signiant.jfrog.io/signiant/api/npm/npm-virt/commander/-/commander-2.20.3.tgz",
+      "integrity": "sha1-/UhehMA+tIgcIHIrpIA16FMa6zM=",
+      "dev": true
+    },
     "concat-map": {
       "version": "0.0.1",
       "resolved": "https://signiant.jfrog.io/signiant/api/npm/npm-virt/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
       "dev": true
-    },
-    "concat-stream": {
-      "version": "1.6.2",
-      "resolved": "https://signiant.jfrog.io/signiant/api/npm/npm-virt/concat-stream/-/concat-stream-1.6.2.tgz",
-      "integrity": "sha1-kEvfGUzTEi/Gdcd/xKw9T/D9GjQ=",
-      "dev": true,
-      "requires": {
-        "buffer-from": "^1.0.0",
-        "inherits": "^2.0.3",
-        "readable-stream": "^2.2.2",
-        "typedarray": "^0.0.6"
-      }
     },
     "core-util-is": {
       "version": "1.0.2",
@@ -444,16 +391,6 @@
       "resolved": "https://signiant.jfrog.io/signiant/api/npm/npm-virt/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
       "integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I=",
       "dev": true
-    },
-    "figures": {
-      "version": "1.7.0",
-      "resolved": "https://signiant.jfrog.io/signiant/api/npm/npm-virt/figures/-/figures-1.7.0.tgz",
-      "integrity": "sha1-y+Hjr/zxzUS4DK3+0o3Hk6lwHS4=",
-      "dev": true,
-      "requires": {
-        "escape-string-regexp": "^1.0.5",
-        "object-assign": "^4.1.0"
-      }
     },
     "find-up": {
       "version": "1.1.2",
@@ -608,55 +545,6 @@
         "rimraf": "^2.5.1"
       }
     },
-    "grunt-contrib-uglify": {
-      "version": "1.0.2",
-      "resolved": "https://signiant.jfrog.io/signiant/api/npm/npm-virt/grunt-contrib-uglify/-/grunt-contrib-uglify-1.0.2.tgz",
-      "integrity": "sha1-rmekb5FT7dTLEYE6Vetpxw19svs=",
-      "dev": true,
-      "requires": {
-        "chalk": "^1.0.0",
-        "lodash": "^4.0.1",
-        "maxmin": "^1.1.0",
-        "uglify-js": "~2.6.2",
-        "uri-path": "^1.0.0"
-      },
-      "dependencies": {
-        "ansi-styles": {
-          "version": "2.2.1",
-          "resolved": "https://signiant.jfrog.io/signiant/api/npm/npm-virt/ansi-styles/-/ansi-styles-2.2.1.tgz",
-          "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
-          "dev": true
-        },
-        "chalk": {
-          "version": "1.1.3",
-          "resolved": "https://signiant.jfrog.io/signiant/api/npm/npm-virt/chalk/-/chalk-1.1.3.tgz",
-          "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "^2.2.1",
-            "escape-string-regexp": "^1.0.2",
-            "has-ansi": "^2.0.0",
-            "strip-ansi": "^3.0.0",
-            "supports-color": "^2.0.0"
-          }
-        },
-        "strip-ansi": {
-          "version": "3.0.1",
-          "resolved": "https://signiant.jfrog.io/signiant/api/npm/npm-virt/strip-ansi/-/strip-ansi-3.0.1.tgz",
-          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-          "dev": true,
-          "requires": {
-            "ansi-regex": "^2.0.0"
-          }
-        },
-        "supports-color": {
-          "version": "2.0.0",
-          "resolved": "https://signiant.jfrog.io/signiant/api/npm/npm-virt/supports-color/-/supports-color-2.0.0.tgz",
-          "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
-          "dev": true
-        }
-      }
-    },
     "grunt-known-options": {
       "version": "1.1.1",
       "resolved": "https://signiant.jfrog.io/signiant/api/npm/npm-virt/grunt-known-options/-/grunt-known-options-1.1.1.tgz",
@@ -722,14 +610,13 @@
         "which": "~1.3.0"
       }
     },
-    "gzip-size": {
+    "grunt-terser": {
       "version": "1.0.0",
-      "resolved": "https://signiant.jfrog.io/signiant/api/npm/npm-virt/gzip-size/-/gzip-size-1.0.0.tgz",
-      "integrity": "sha1-Zs+LEBBHInuVus5uodoMF37Vwi8=",
+      "resolved": "https://signiant.jfrog.io/signiant/api/npm/npm-virt/grunt-terser/-/grunt-terser-1.0.0.tgz",
+      "integrity": "sha1-y0bWRf5R7Js7yx8329LzES2R55E=",
       "dev": true,
       "requires": {
-        "browserify-zlib": "^0.1.4",
-        "concat-stream": "^1.4.1"
+        "terser": "^4.3.9"
       }
     },
     "har-schema": {
@@ -746,15 +633,6 @@
       "requires": {
         "ajv": "^6.5.5",
         "har-schema": "^2.0.0"
-      }
-    },
-    "has-ansi": {
-      "version": "2.0.0",
-      "resolved": "https://signiant.jfrog.io/signiant/api/npm/npm-virt/has-ansi/-/has-ansi-2.0.0.tgz",
-      "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
-      "dev": true,
-      "requires": {
-        "ansi-regex": "^2.0.0"
       }
     },
     "has-color": {
@@ -836,12 +714,6 @@
       "version": "0.2.1",
       "resolved": "https://signiant.jfrog.io/signiant/api/npm/npm-virt/is-arrayish/-/is-arrayish-0.2.1.tgz",
       "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=",
-      "dev": true
-    },
-    "is-buffer": {
-      "version": "1.1.6",
-      "resolved": "https://signiant.jfrog.io/signiant/api/npm/npm-virt/is-buffer/-/is-buffer-1.1.6.tgz",
-      "integrity": "sha1-76ouqdqg16suoTqXsritUf776L4=",
       "dev": true
     },
     "is-finite": {
@@ -951,21 +823,6 @@
         "verror": "1.10.0"
       }
     },
-    "kind-of": {
-      "version": "3.2.2",
-      "resolved": "https://signiant.jfrog.io/signiant/api/npm/npm-virt/kind-of/-/kind-of-3.2.2.tgz",
-      "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-      "dev": true,
-      "requires": {
-        "is-buffer": "^1.1.5"
-      }
-    },
-    "lazy-cache": {
-      "version": "1.0.4",
-      "resolved": "https://signiant.jfrog.io/signiant/api/npm/npm-virt/lazy-cache/-/lazy-cache-1.0.4.tgz",
-      "integrity": "sha1-odePw6UEdMuAhF07O24dpJpEbo4=",
-      "dev": true
-    },
     "load-json-file": {
       "version": "1.1.0",
       "resolved": "https://signiant.jfrog.io/signiant/api/npm/npm-virt/load-json-file/-/load-json-file-1.1.0.tgz",
@@ -985,12 +842,6 @@
       "integrity": "sha1-tEf2ZwoEVbv+7dETku/zMOoJdUg=",
       "dev": true
     },
-    "longest": {
-      "version": "1.0.1",
-      "resolved": "https://signiant.jfrog.io/signiant/api/npm/npm-virt/longest/-/longest-1.0.1.tgz",
-      "integrity": "sha1-MKCy2jj3N3DoKUoNIuZiXtd9AJc=",
-      "dev": true
-    },
     "loud-rejection": {
       "version": "1.6.0",
       "resolved": "https://signiant.jfrog.io/signiant/api/npm/npm-virt/loud-rejection/-/loud-rejection-1.6.0.tgz",
@@ -1006,54 +857,6 @@
       "resolved": "https://signiant.jfrog.io/signiant/api/npm/npm-virt/map-obj/-/map-obj-1.0.1.tgz",
       "integrity": "sha1-2TPOuSBdgr3PSIb2dCvcK03qFG0=",
       "dev": true
-    },
-    "maxmin": {
-      "version": "1.1.0",
-      "resolved": "https://signiant.jfrog.io/signiant/api/npm/npm-virt/maxmin/-/maxmin-1.1.0.tgz",
-      "integrity": "sha1-cTZehKmd2Piz99X94vANHn9zvmE=",
-      "dev": true,
-      "requires": {
-        "chalk": "^1.0.0",
-        "figures": "^1.0.1",
-        "gzip-size": "^1.0.0",
-        "pretty-bytes": "^1.0.0"
-      },
-      "dependencies": {
-        "ansi-styles": {
-          "version": "2.2.1",
-          "resolved": "https://signiant.jfrog.io/signiant/api/npm/npm-virt/ansi-styles/-/ansi-styles-2.2.1.tgz",
-          "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
-          "dev": true
-        },
-        "chalk": {
-          "version": "1.1.3",
-          "resolved": "https://signiant.jfrog.io/signiant/api/npm/npm-virt/chalk/-/chalk-1.1.3.tgz",
-          "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "^2.2.1",
-            "escape-string-regexp": "^1.0.2",
-            "has-ansi": "^2.0.0",
-            "strip-ansi": "^3.0.0",
-            "supports-color": "^2.0.0"
-          }
-        },
-        "strip-ansi": {
-          "version": "3.0.1",
-          "resolved": "https://signiant.jfrog.io/signiant/api/npm/npm-virt/strip-ansi/-/strip-ansi-3.0.1.tgz",
-          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-          "dev": true,
-          "requires": {
-            "ansi-regex": "^2.0.0"
-          }
-        },
-        "supports-color": {
-          "version": "2.0.0",
-          "resolved": "https://signiant.jfrog.io/signiant/api/npm/npm-virt/supports-color/-/supports-color-2.0.0.tgz",
-          "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
-          "dev": true
-        }
-      }
     },
     "meow": {
       "version": "3.7.0",
@@ -1178,12 +981,6 @@
         "wrappy": "1"
       }
     },
-    "pako": {
-      "version": "0.2.9",
-      "resolved": "https://signiant.jfrog.io/signiant/api/npm/npm-virt/pako/-/pako-0.2.9.tgz",
-      "integrity": "sha1-8/dSL073gjSNqBYbrZ7P1Rv4OnU=",
-      "dev": true
-    },
     "parse-json": {
       "version": "2.2.0",
       "resolved": "https://signiant.jfrog.io/signiant/api/npm/npm-virt/parse-json/-/parse-json-2.2.0.tgz",
@@ -1252,22 +1049,6 @@
         "pinkie": "^2.0.0"
       }
     },
-    "pretty-bytes": {
-      "version": "1.0.4",
-      "resolved": "https://signiant.jfrog.io/signiant/api/npm/npm-virt/pretty-bytes/-/pretty-bytes-1.0.4.tgz",
-      "integrity": "sha1-CiLoIQYJrTVUL4yNXSFZr/B1HIQ=",
-      "dev": true,
-      "requires": {
-        "get-stdin": "^4.0.1",
-        "meow": "^3.1.0"
-      }
-    },
-    "process-nextick-args": {
-      "version": "2.0.1",
-      "resolved": "https://signiant.jfrog.io/signiant/api/npm/npm-virt/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
-      "integrity": "sha1-eCDZsWEgzFXKmud5JoCufbptf+I=",
-      "dev": true
-    },
     "psl": {
       "version": "1.4.0",
       "resolved": "https://signiant.jfrog.io/signiant/api/npm/npm-virt/psl/-/psl-1.4.0.tgz",
@@ -1313,29 +1094,6 @@
         "read-pkg": "^1.0.0"
       }
     },
-    "readable-stream": {
-      "version": "2.3.6",
-      "resolved": "https://signiant.jfrog.io/signiant/api/npm/npm-virt/readable-stream/-/readable-stream-2.3.6.tgz",
-      "integrity": "sha1-sRwn2IuP8fvgcGQ8+UsMea4bCq8=",
-      "dev": true,
-      "requires": {
-        "core-util-is": "~1.0.0",
-        "inherits": "~2.0.3",
-        "isarray": "~1.0.0",
-        "process-nextick-args": "~2.0.0",
-        "safe-buffer": "~5.1.1",
-        "string_decoder": "~1.1.1",
-        "util-deprecate": "~1.0.1"
-      },
-      "dependencies": {
-        "safe-buffer": {
-          "version": "5.1.2",
-          "resolved": "https://signiant.jfrog.io/signiant/api/npm/npm-virt/safe-buffer/-/safe-buffer-5.1.2.tgz",
-          "integrity": "sha1-mR7GnSluAxN0fVm9/St0XDX4go0=",
-          "dev": true
-        }
-      }
-    },
     "redent": {
       "version": "1.0.0",
       "resolved": "https://signiant.jfrog.io/signiant/api/npm/npm-virt/redent/-/redent-1.0.0.tgz",
@@ -1345,12 +1103,6 @@
         "indent-string": "^2.1.0",
         "strip-indent": "^1.0.1"
       }
-    },
-    "repeat-string": {
-      "version": "1.6.1",
-      "resolved": "https://signiant.jfrog.io/signiant/api/npm/npm-virt/repeat-string/-/repeat-string-1.6.1.tgz",
-      "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc=",
-      "dev": true
     },
     "repeating": {
       "version": "2.0.1",
@@ -1396,15 +1148,6 @@
       "dev": true,
       "requires": {
         "path-parse": "^1.0.6"
-      }
-    },
-    "right-align": {
-      "version": "0.1.3",
-      "resolved": "https://signiant.jfrog.io/signiant/api/npm/npm-virt/right-align/-/right-align-0.1.3.tgz",
-      "integrity": "sha1-YTObci/mo1FWiSENJOFMlhSGE+8=",
-      "dev": true,
-      "requires": {
-        "align-text": "^0.1.1"
       }
     },
     "rimraf": {
@@ -1462,11 +1205,23 @@
       "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
       "dev": true
     },
-    "source-map": {
-      "version": "0.5.7",
-      "resolved": "https://signiant.jfrog.io/signiant/api/npm/npm-virt/source-map/-/source-map-0.5.7.tgz",
-      "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
-      "dev": true
+    "source-map-support": {
+      "version": "0.5.16",
+      "resolved": "https://signiant.jfrog.io/signiant/api/npm/npm-virt/source-map-support/-/source-map-support-0.5.16.tgz",
+      "integrity": "sha1-CuBp5/47p1OMZMmFFeNTOerFoEI=",
+      "dev": true,
+      "requires": {
+        "buffer-from": "^1.0.0",
+        "source-map": "^0.6.0"
+      },
+      "dependencies": {
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://signiant.jfrog.io/signiant/api/npm/npm-virt/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha1-dHIq8y6WFOnCh6jQu95IteLxomM=",
+          "dev": true
+        }
+      }
     },
     "spdx-correct": {
       "version": "3.1.0",
@@ -1523,23 +1278,6 @@
         "tweetnacl": "~0.14.0"
       }
     },
-    "string_decoder": {
-      "version": "1.1.1",
-      "resolved": "https://signiant.jfrog.io/signiant/api/npm/npm-virt/string_decoder/-/string_decoder-1.1.1.tgz",
-      "integrity": "sha1-nPFhG6YmhdcDCunkujQUnDrwP8g=",
-      "dev": true,
-      "requires": {
-        "safe-buffer": "~5.1.0"
-      },
-      "dependencies": {
-        "safe-buffer": {
-          "version": "5.1.2",
-          "resolved": "https://signiant.jfrog.io/signiant/api/npm/npm-virt/safe-buffer/-/safe-buffer-5.1.2.tgz",
-          "integrity": "sha1-mR7GnSluAxN0fVm9/St0XDX4go0=",
-          "dev": true
-        }
-      }
-    },
     "strip-ansi": {
       "version": "0.1.1",
       "resolved": "https://signiant.jfrog.io/signiant/api/npm/npm-virt/strip-ansi/-/strip-ansi-0.1.1.tgz",
@@ -1571,6 +1309,25 @@
       "dev": true,
       "requires": {
         "has-flag": "^3.0.0"
+      }
+    },
+    "terser": {
+      "version": "4.4.2",
+      "resolved": "https://signiant.jfrog.io/signiant/api/npm/npm-virt/terser/-/terser-4.4.2.tgz",
+      "integrity": "sha1-RI//rQJF9Miid86JeItFi/13Bug=",
+      "dev": true,
+      "requires": {
+        "commander": "^2.20.0",
+        "source-map": "~0.6.1",
+        "source-map-support": "~0.5.12"
+      },
+      "dependencies": {
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://signiant.jfrog.io/signiant/api/npm/npm-virt/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha1-dHIq8y6WFOnCh6jQu95IteLxomM=",
+          "dev": true
+        }
       }
     },
     "tough-cookie": {
@@ -1612,38 +1369,6 @@
       "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
       "dev": true
     },
-    "typedarray": {
-      "version": "0.0.6",
-      "resolved": "https://signiant.jfrog.io/signiant/api/npm/npm-virt/typedarray/-/typedarray-0.0.6.tgz",
-      "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
-      "dev": true
-    },
-    "uglify-js": {
-      "version": "2.6.4",
-      "resolved": "https://signiant.jfrog.io/signiant/api/npm/npm-virt/uglify-js/-/uglify-js-2.6.4.tgz",
-      "integrity": "sha1-ZeovswWck5RpLxX+2HwrNsFrmt8=",
-      "dev": true,
-      "requires": {
-        "async": "~0.2.6",
-        "source-map": "~0.5.1",
-        "uglify-to-browserify": "~1.0.0",
-        "yargs": "~3.10.0"
-      },
-      "dependencies": {
-        "async": {
-          "version": "0.2.10",
-          "resolved": "https://signiant.jfrog.io/signiant/api/npm/npm-virt/async/-/async-0.2.10.tgz",
-          "integrity": "sha1-trvgsGdLnXGXCMo43owjfLUmw9E=",
-          "dev": true
-        }
-      }
-    },
-    "uglify-to-browserify": {
-      "version": "1.0.2",
-      "resolved": "https://signiant.jfrog.io/signiant/api/npm/npm-virt/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz",
-      "integrity": "sha1-bgkk1r2mta/jSeOabWMoUKD4grc=",
-      "dev": true
-    },
     "underscore": {
       "version": "1.6.0",
       "resolved": "https://signiant.jfrog.io/signiant/api/npm/npm-virt/underscore/-/underscore-1.6.0.tgz",
@@ -1676,12 +1401,6 @@
           "dev": true
         }
       }
-    },
-    "uri-path": {
-      "version": "1.0.0",
-      "resolved": "https://signiant.jfrog.io/signiant/api/npm/npm-virt/uri-path/-/uri-path-1.0.0.tgz",
-      "integrity": "sha1-l0fwGDWJM8Md4PzP2C0TjmcmLjI=",
-      "dev": true
     },
     "url": {
       "version": "0.10.3",
@@ -1735,18 +1454,6 @@
         "isexe": "^2.0.0"
       }
     },
-    "window-size": {
-      "version": "0.1.0",
-      "resolved": "https://signiant.jfrog.io/signiant/api/npm/npm-virt/window-size/-/window-size-0.1.0.tgz",
-      "integrity": "sha1-VDjNLqk7IC76Ohn+iIeu58lPnJ0=",
-      "dev": true
-    },
-    "wordwrap": {
-      "version": "0.0.2",
-      "resolved": "https://signiant.jfrog.io/signiant/api/npm/npm-virt/wordwrap/-/wordwrap-0.0.2.tgz",
-      "integrity": "sha1-t5Zpu0LstAn4PVg8rVLKF+qhZD8=",
-      "dev": true
-    },
     "wrappy": {
       "version": "1.0.2",
       "resolved": "https://signiant.jfrog.io/signiant/api/npm/npm-virt/wrappy/-/wrappy-1.0.2.tgz",
@@ -1768,26 +1475,6 @@
       "resolved": "https://signiant.jfrog.io/signiant/api/npm/npm-virt/xmlbuilder/-/xmlbuilder-9.0.7.tgz",
       "integrity": "sha1-Ey7mPS7FVlxVfiD0wi35rKaGsQ0=",
       "dev": true
-    },
-    "yargs": {
-      "version": "3.10.0",
-      "resolved": "https://signiant.jfrog.io/signiant/api/npm/npm-virt/yargs/-/yargs-3.10.0.tgz",
-      "integrity": "sha1-9+572FfdfB0tOMDnTvvWgdFDH9E=",
-      "dev": true,
-      "requires": {
-        "camelcase": "^1.0.2",
-        "cliui": "^2.1.0",
-        "decamelize": "^1.0.0",
-        "window-size": "0.1.0"
-      },
-      "dependencies": {
-        "camelcase": {
-          "version": "1.2.1",
-          "resolved": "https://signiant.jfrog.io/signiant/api/npm/npm-virt/camelcase/-/camelcase-1.2.1.tgz",
-          "integrity": "sha1-m7UwTS4LVmmLLHWLCKPqqdqlijk=",
-          "dev": true
-        }
-      }
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -3,8 +3,8 @@
   "description": "A lambda backed dynamodb cross region replication solution",
   "version": "1.0.0",
   "author": "Jonathan Seed <jonathan.j.seed@gmail.com>",
-  "engines" : {
-    "node" : ">=10"
+  "engines": {
+    "node": ">=10"
   },
   "repository": {
     "type": "git",
@@ -23,6 +23,6 @@
     "cfn-include": "^0.6.3",
     "grunt": "^1.0.1",
     "grunt-contrib-clean": "^1.0.0",
-    "grunt-contrib-uglify": "^1.0.1"
+    "grunt-terser": "^1.0.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -3,6 +3,9 @@
   "description": "A lambda backed dynamodb cross region replication solution",
   "version": "1.0.0",
   "author": "Jonathan Seed <jonathan.j.seed@gmail.com>",
+  "engines" : {
+    "node" : ">=10"
+  },
   "repository": {
     "type": "git",
     "url": "https://github.com/Signiant/dynamodb-replication"


### PR DESCRIPTION
It appears, somewhere between Node 8 and 10 Runtime environments, the global console object is now persisted between different Lambda executions.

That means, with each invocation, the `console.bind` function is prepending more and more prefixes to each previous binding, leading to potentially infinite numbers of prefixes and logging. This is bad!

The fix basically removes the binding and replaces it with a direct log statement.

It is not ideal to replicate this pattern, rather than using shared code, but I see that there is no package and deployment as part of this project, so I just copy-pasta'd the whole thing.
A lot of other items here could be modernized, but it is probably no longer worth the effort due to the advent of global tables. Fixing this at least prevents others from generating infinite logs if they haven't yet had the time to migrate.
